### PR TITLE
Adv symmetry/add serialisation

### DIFF
--- a/experimentation/revolve2/experimentation/genotypes/cellular_automata/ca_genotype.py
+++ b/experimentation/revolve2/experimentation/genotypes/cellular_automata/ca_genotype.py
@@ -347,6 +347,22 @@ class CAGenotype(IGenotype[CAInitParameters]):
         newitem._ca_type.generate_random_genotype(params.nr_rules)
         return newitem
 
+    def to_json(self) -> Dict[str, Any]:
+        """Seralise the genotype to Json"""
+        return {
+            "type": "CAGenotype",
+            "gene": {str(k): v for k, v in self._ca_type.rule_set.items()},
+            "params": self.params.to_json(),
+        }
+
+    @classmethod
+    def from_json(cls, json_out: Dict[str, Any]) -> Self:
+        """Deserialise the genotype from Json"""
+        assert json_out["type"] == "CAGenotype"
+        newitem = cls(CAInitParameters.from_json(json_out["params"]))
+        newitem._ca_type.rule_set = {eval(k): v for k, v in json_out["gene"].items()}
+        return newitem
+
 
 class SymmetricalCAGenotype(SymmetricalGenotype):
     @classmethod

--- a/experimentation/revolve2/experimentation/genotypes/grn/impl.py
+++ b/experimentation/revolve2/experimentation/genotypes/grn/impl.py
@@ -7,6 +7,8 @@ import numpy as np
 from revolve2.experimentation.genotypes.protocols import GenotypeInitParams, IGenotype
 from revolve2.experimentation.genotypes.protocols.symmetrical import SymmetricalGenotype
 from revolve2.modular_robot import Body
+
+from typing import Dict, Any
 from typing_extensions import Self
 
 from .crossover import crossover_v1
@@ -51,6 +53,25 @@ class GRNGenotype(IGenotype[GRNInitParams]):
     def crossover(self, rng: np.random.Generator, __o: Self) -> Self:
         genotype = crossover_v1(self.genotype, __o.genotype, rng)
         return self._from_genotype(genotype, self.params, rng)
+
+    def to_json(self) -> Dict[str, Any]:
+        """Seralise the genotype to Json"""
+        return {
+            "type": "GRNGenotype",
+            "gene": self.genotype.genotype,
+            "params": self.params.to_json(),
+            "seed": self.seed,
+        }
+
+    @classmethod
+    def from_json(cls, json_out: Dict[str, Any]) -> Self:
+        """Deserialise the genotype from Json"""
+        assert json_out["type"] == "GRNGenotype"
+        return cls(
+            GRNInitParams.from_json(json_out["params"]),
+            Genotype(json_out["gene"]),
+            json_out["seed"],
+        )
 
     @classmethod
     def random(cls, params: GRNInitParams, rng: np.random.Generator) -> Self:

--- a/experimentation/revolve2/experimentation/genotypes/protocols/genotype.py
+++ b/experimentation/revolve2/experimentation/genotypes/protocols/genotype.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
-from typing import Generic, List, TypeVar
+from typing import Any, Dict, Generic, List, TypeVar
 
 from typing_extensions import TYPE_CHECKING, Self
 
@@ -14,6 +15,14 @@ class GenotypeInitParams(ABC):
     @abstractmethod
     def __init__(self) -> None:
         ...
+
+    def to_json(self) -> Dict[str, Any]:
+        """Return the Json of the params"""
+        return self.__dict__
+
+    @classmethod
+    def from_json(cls, json_out: Dict[str, Any]) -> Self:
+        return cls(**json_out)
 
 
 InitParams = TypeVar("InitParams", bound=GenotypeInitParams)
@@ -43,6 +52,15 @@ class IGenotype(Generic[InitParams], ABC):
     @abstractmethod
     def crossover(self, rng: np.random.Generator, __o: Self) -> Self:
         """Perform crossover between two individuals. Return a new copy"""
+
+    @abstractmethod
+    def to_json(self) -> Dict[str, Any]:
+        """Seralise the genotype to Json"""
+
+    @classmethod
+    @abstractmethod
+    def from_json(cls, json_out: Dict[str, Any]) -> Self:
+        """Deserialise the genotype from Json"""
 
     @classmethod
     @abstractmethod

--- a/experimentation/revolve2/experimentation/genotypes/tree/tree_genotype.py
+++ b/experimentation/revolve2/experimentation/genotypes/tree/tree_genotype.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
-from typing import TypeVar, cast
+from typing import Any, Dict, TypeVar, cast
 
 from numpy.random import Generator
 from revolve2.experimentation.genotypes.protocols import (
@@ -85,6 +86,22 @@ class TreeGenotype(IGenotype[TreeInitParameters]):
             rng.choice(node.valid_attatchments()),
         )
         return self.__class__(self._params, newtree)
+
+    def to_json(self) -> Dict[str, Any]:
+        """Seralise the genotype to Json"""
+        return {
+            "type": "TreeGenotype",
+            "gene": self._tree.to_json(),
+            "params": self._params.to_json(),
+        }
+
+    @classmethod
+    def from_json(cls, json_out: Dict[str, Any]) -> Self:
+        """Deserialise the genotype from Json"""
+        assert json_out["type"] == "TreeGenotype"
+        params = TreeInitParameters.from_json(json_out["params"])
+        tree = CoreNode.from_json(json_out["gene"])
+        return cls(params, tree)
 
 
 class SymmetricalTreeGenotype(SymmetricalGenotype):


### PR DESCRIPTION
Some hacks to get a `from_json` and `to_json` to work on all three genotypes

Uses `eval` as a parser and strings for type checking. 6/10, gets the job done.